### PR TITLE
Simplify workflow to download external artifact

### DIFF
--- a/.github/workflows/updatebook.yml
+++ b/.github/workflows/updatebook.yml
@@ -1,111 +1,25 @@
-# This is a basic workflow to help you get started with Actions
+name: Download Quartobook
 
-name: CI
-
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
-    runs-on: macos-latest
+  download:
+    runs-on: ubuntu-latest
     permissions:
-      actions: read # Required to read details about other workflow runs
+      actions: read
       contents: read
 
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
-
-      # Runs a single command using the runners shell   
-      - name: Download artifact
-        id: download-artifact
-        uses: dawidd6/action-download-artifact@v11
-        #continue-on-error: true
+      - name: Download quartobook artifact
+        uses: dawidd6/action-download-artifact@v2
         with:
-          # Optional, GitHub token, a Personal Access Token with `public_repo` scope if needed
-          # Required, if the artifact is from a different repo
-          # Required, if the repo is private a Personal Access Token with `repo` scope is needed or GitHub token in a job where the permissions `action` scope set to `read`
-          github_token: ${{secrets.GH_PAT}}
-          # Optional, workflow file name or ID
-          # If not specified, will be inferred from run_id (if run_id is specified), or will be the current workflow
-          workflow: R-targets.yml
-          # If no workflow is set and workflow_search set to true, then the most recent workflow matching
-          # all other criteria will be looked up instead of using the current workflow
-          workflow_search: true
-          # Optional, the status or conclusion of a completed workflow to search for
-          # Can be one of a workflow conclusion:
-          #   "failure", "success", "neutral", "cancelled", "skipped", "timed_out", "action_required"
-          # Or a workflow status:
-          #   "completed", "in_progress", "queued"
-          # Use the empty string ("") to ignore status or conclusion in the search
-          #workflow_conclusion: success
-          workflow_conclusion: success
-          # Optional, will get head commit SHA
-          #pr: ${{github.event.pull_request.number}}
-          # Optional, no need to specify if PR is
-          #commit: ${{github.event.pull_request.head.sha}}
-          # Optional, will use the specified branch. Defaults to all branches
-          #branch: master
-          # Optional, branch/tag/commit ID to reference. This can supersede both
-          # branch and commit above.
-          #ref: master
-          # Optional, defaults to all types
-          #event: push
-          # Optional, will use specified workflow run
-          # use ${{ github.event.workflow_run.id }} when your action runs in a workflow_run event
-          # and wants to download from the triggering workflow run
-          #run_id: ${{ github.event.workflow_run.id }}
-          # Optional, run number from the workflow
-          #run_number: 34
-          # Optional, uploaded artifact name,
-          # will download all artifacts if not specified
-          # and extract them into respective subdirectories
-          # https://github.com/actions/download-artifact#download-all-artifacts
-          # is treated as a regular expression if input name_is_regexp is true
-          # will download only those artifacts with a name that matches this regular expression
-          # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions
-          name: quartobook
-          # Optional, name is treated as a regular expression if set true
-          name_is_regexp: false
-          # Optional, a directory where to extract artifact(s), defaults to the current directory
-          path: book
-          # Optional, defaults to current repo
           repo: edalfon/ptfr
-          # Optional, check the workflow run to whether it has an artifact
-          # then will get the last available artifact from the previous workflow
-          # default false, just try to download from the last one
-          check_artifacts: true
-          # Optional, search for the last workflow run whose stored an artifact named as in `name` input
-          # default false
+          github_token: ${{ secrets.GH_PAT }}
+          workflow: R-targets.yml
+          workflow_conclusion: success
+          branch: main
+          name: quartobook
+          path: book
           search_artifacts: true
-          # Optional, choose to skip unpacking the downloaded artifact(s)
-          # default false
-          skip_unpack: false
-          # Optional, choose how to exit the action if no artifact is found
-          # can be one of:
-          #  "fail", "warn", "ignore"
-          # default fail
-          if_no_artifact_found: fail
-          # Optional, include forks when searching for artifacts
-          # default false
-          allow_forks: true
-          # Optional, choose to unpack the downloaded artifact(s) using `unzip` system utility
-          # default false
-          use_unzip: false
-          # Optional, if multiple artifacts are found with `name_is_regexp` set to `true`, merge them into one directory
-          # default false
-          merge_multiple: false
-          
+          check_artifacts: true


### PR DESCRIPTION
## Summary
- replace the existing workflow with a focused job that downloads the `quartobook` artifact from `edalfon/ptfr`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da1d224030833090de3ee53c4482bb